### PR TITLE
Added --ipv4 option to GetIP module

### DIFF
--- a/modules/GetIP/main.c
+++ b/modules/GetIP/main.c
@@ -62,6 +62,7 @@ void get_ip(wchar_t *url, wchar_t *buf, int size) {
 	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_write);
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &data);
+	curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
 	if (!curl_easy_perform(curl) && data.len && *data.ptr) {
 		MultiByteToWideChar(CP_UTF8, 0, data.ptr, -1, buf, size);
 	}


### PR DESCRIPTION
If the network is IPv6, the IPv6 address is copied to the clipboard.
```
2001:db8:27015
```

--ipv4 option is used to avoid this.
```
203.0.113.0:27015
```